### PR TITLE
Compress path and action info when window is too narrow

### DIFF
--- a/src/shell/StatusBar.svelte
+++ b/src/shell/StatusBar.svelte
@@ -127,7 +127,7 @@
 
     .repo-bar {
         display: grid;
-        grid-template-columns: minmax(auto, 40%) 1fr minmax(auto, 40%);
+        grid-template-columns: minmax(120px, max-content) 1fr minmax(120px, max-content);
     }
 
     .drag-bar {
@@ -155,11 +155,19 @@
         height: 100%;
         padding: 0 3px;
         justify-content: end;
+        min-width: 0;
     }
 
-    #status-operation > span,
+    #status-operation > span {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
     #status-workspace {
         white-space: nowrap;
+        direction: rtl;
+        text-align: left;
         overflow: hidden;
         text-overflow: ellipsis;
     }


### PR DESCRIPTION
The compression direction is as follows:  
Repo path: Prioritize compressing the header  
Operation status: Prioritize compressing the tail  

Demo:  

https://github.com/user-attachments/assets/69caa439-b796-4d7d-bf88-a8a37c59ea14