### PR TITLE
Supports rendering git emojis in the history tree

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@tauri-apps/api": "^2.0.0-beta.0",
         "@tauri-apps/plugin-shell": "^2.0.0-beta.0",
         "feather-icons": "^4.29.1",
+        "gitmojis": "^3.15.0",
         "modern-normalize": "^2.0.0",
       },
       "devDependencies": {
@@ -209,6 +210,8 @@
     "fs.realpath": ["fs.realpath@1.0.0", "https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gitmojis": ["gitmojis@3.15.0", "https://registry.npmmirror.com/gitmojis/-/gitmojis-3.15.0.tgz", {}, "sha512-28sothO0+6UuXx0fnJXi4kqy2/dKeFN3xL2Ss5k5K5ECBJMi5T2kZLY92xys3/+YD+AgKHgeiw7YQpYKnkCLMg=="],
 
     "glob": ["glob@7.2.3", "https://registry.npmmirror.com/glob/-/glob-7.2.3.tgz", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/api": "^2.0.0-beta.0",
     "@tauri-apps/plugin-shell": "^2.0.0-beta.0",
     "feather-icons": "^4.29.1",
+    "gitmojis": "^3.15.0",
     "modern-normalize": "^2.0.0"
   },
   "devDependencies": {

--- a/src/controls/EmojiText.svelte
+++ b/src/controls/EmojiText.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    import { gitmojis } from "gitmojis";
+
+    export let text: string;
+
+    const emojiMap = new Map();
+    gitmojis.forEach((gitmoji) => {
+        emojiMap.set(gitmoji.code, gitmoji.emoji);
+    });
+
+    function renderEmoji(text: string): string {
+        if (!text) return text;
+
+        return text.replace(/:([a-zA-Z0-9_+-]+):/g, (match, code) => {
+            const emoji = emojiMap.get(`:${code}:`);
+            return emoji || match;
+        });
+    }
+
+    $: renderedText = renderEmoji(text);
+</script>
+
+<span>{renderedText}</span>

--- a/src/objects/RevisionObject.svelte
+++ b/src/objects/RevisionObject.svelte
@@ -9,6 +9,7 @@
     import RevisionMutator from "../mutators/RevisionMutator";
     import TagObject from "./TagObject.svelte";
     import AuthorSpan from "../controls/AuthorSpan.svelte";
+    import EmojiText from "../controls/EmojiText.svelte";
 
     export let header: RevHeader;
     export let child: RevHeader | null = null;
@@ -50,10 +51,11 @@
             <span
                 class="text desc truncate"
                 class:indescribable={!context && header.description.lines[0] == ""}>
-                {dragHint ??
-                    (header.description.lines[0] == ""
-                        ? "(no description set)"
-                        : header.description.lines[0])}
+                {#if header.description.lines[0] == ""}
+                    {dragHint ?? "(no description set)"}
+                {:else}
+                    <EmojiText text={dragHint ?? header.description.lines[0]} />
+                {/if}
             </span>
 
             <span class="email"><AuthorSpan author={header.author} /></span>
@@ -82,11 +84,11 @@
                 <span
                     class="text desc truncate"
                     class:indescribable={!context && header.description.lines[0] == ""}>
-                    {dragHint ??
-                        dropHint ??
-                        (header.description.lines[0] == ""
-                            ? "(no description set)"
-                            : header.description.lines[0])}
+                    {#if header.description.lines[0] == ""}
+                        {dragHint ?? dropHint ?? "(no description set)"}
+                    {:else}
+                        <EmojiText text={dragHint ?? dropHint ?? header.description.lines[0]} />
+                    {/if}
                 </span>
 
                 <span class="email"><AuthorSpan author={header.author} /></span>


### PR DESCRIPTION
Previously, when projects used Conventional Commits with gitmoji, `gg` couldn't render them correctly (though `jj` couldn't either). Below is an example using https://github.com/vivaxy/vscode-conventional-commits:

> `jj log -r ::`

<img src="https://github.com/user-attachments/assets/1264995c-7b7e-4d35-8fa6-7bbd376bb9f4" width="500">

---

> How it appears in `gg`

<img src="https://github.com/user-attachments/assets/64b8a775-2a5f-4b55-bc59-5807031123e8" width="500">

---

> How it looks in VS Code

<img src="https://github.com/user-attachments/assets/b873444d-b8f7-4026-af27-5e7e5f0d11bf" width="500">

---

> How it appears on GitHub

<img src="https://github.com/user-attachments/assets/f31fba2a-6560-4c86-a437-f46adb0efb6e" width="500">

---

As we can see, most user-facing interfaces render gitmoji properly, and I believe `gg` shouldn't be an exception.

After this PR, we'll render gitmoji in display-focused areas while keeping the original format in the description edit text box:

<img src="https://github.com/user-attachments/assets/7c1207c1-1489-499a-8f80-3c04b92e6e5b" width="500">
