### PR TITLE
Fix overscroll on macOS

### DIFF
--- a/src/GraphLog.svelte
+++ b/src/GraphLog.svelte
@@ -75,7 +75,7 @@
 
     $: graphHeight = Math.max(containerHeight, rows.length * rowHeight);
     $: visibleRows = Math.ceil(containerHeight / rowHeight) + 1;
-    $: startIndex = Math.floor(scrollTop / rowHeight);
+    $: startIndex = Math.floor(Math.max(scrollTop, 0) / rowHeight);
     $: endIndex = startIndex + visibleRows;
     $: overlap = startIndex % visibleRows;
     $: visibleSlice = {


### PR DESCRIPTION
Scrollable views on macOS have a bouncy overscroll effect, similar to iPhones. This means `scrollTop` can get negative, which was messing with `startIndex` calculation and making all the contents disappear.

Before this patch:

https://github.com/user-attachments/assets/71582c17-6db2-4625-9c98-939ee32314b6


After this patch:

https://github.com/user-attachments/assets/2ca425f5-4c10-41a9-8800-13522cf2faf7


