### PR TITLE
enables ID to be copied by clicking

### DIFF
--- a/src/RevisionPane.svelte
+++ b/src/RevisionPane.svelte
@@ -14,6 +14,8 @@
     import AuthorSpan from "./controls/AuthorSpan.svelte";
     import ListWidget, { type List } from "./controls/ListWidget.svelte";
     import type { RevChange } from "./messages/RevChange";
+    import type { ChangeId } from "./messages/ChangeId";
+    import type { CommitId } from "./messages/CommitId";
 
     export let rev: Extract<RevResult, { type: "Detail" }>;
 
@@ -100,12 +102,46 @@
             return null;
         }
     }
+
+    function getShortId(id: ChangeId | CommitId) {
+        return id.prefix + id.rest.substring(0, 2);
+    }
+    function getStandardId(id: ChangeId | CommitId) {
+        return id.prefix + id.rest.substring(0, 8 - id.prefix.length);
+    }
+    function copyId(id: ChangeId | CommitId, event: MouseEvent) {
+        if (event.ctrlKey || event.metaKey) {
+            navigator.clipboard.writeText(getStandardId(id));
+        } else {
+            navigator.clipboard.writeText(getShortId(id));
+        }
+    }
+    $: shortChangeId = getShortId(rev.header.id.change);
+    $: standardChangeId = getStandardId(rev.header.id.change);
+    $: shortCommitId = getShortId(rev.header.id.commit);
+    $: standardCommitId = getStandardId(rev.header.id.commit);
 </script>
 
 <Pane>
     <h2 slot="header" class="header">
         <span class="title">
-            <IdSpan id={rev.header.id.change} /> | <IdSpan id={rev.header.id.commit} />
+            <ActionWidget
+                tip={`click to copy ${shortChangeId}\
+                \nCtrl/⌘+click to copy ${standardChangeId}`}
+                onClick={(event) => {
+                    copyId(rev.header.id.change, event);
+                }}>
+                <Icon name="copy" /><IdSpan id={rev.header.id.change} />
+            </ActionWidget>
+            |
+            <ActionWidget
+                tip={`click to copy ${shortCommitId}\
+                \nCtrl/⌘+click to copy ${standardCommitId}`}
+                onClick={(event) => {
+                    copyId(rev.header.id.commit, event);
+                }}>
+                <Icon name="copy" /><IdSpan id={rev.header.id.commit} />
+            </ActionWidget>
             {#if rev.header.is_working_copy}
                 | Working copy
             {/if}
@@ -234,6 +270,9 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        display: flex;
+        align-items: center;
+        gap: 6px;
     }
 
     .checkout-commands {

--- a/src/controls/ActionWidget.svelte
+++ b/src/controls/ActionWidget.svelte
@@ -43,6 +43,18 @@
         padding: 1px 6px;
     }
 
+    button :global(.id) {
+        color: var(--ctp-crust) !important;
+    }
+    button :global(.id .ChangeId) {
+        color: rgb(198, 35, 117);
+        font-weight: bold;
+    }
+    button :global(.id .CommitId) {
+        color: rgb(38, 107, 255);
+        font-weight: bold;
+    }
+
     button:not(:disabled) {
         &:hover {
             background: var(--ctp-maroon);


### PR DESCRIPTION
Users can now quickly copy the Change/Commit ID by clicking on it in the top-right corner. 

To ensure the CLI command history remains identifiable even after a certain period, the default copied text follows the format: `shortest prefix + last two characters`. 
At the same time, you can obtain an eight-character ID like Git's by using `Ctrl+click`.  

Demo:  
![PixPin_2025-06-23_22-02-16](https://github.com/user-attachments/assets/1af8b495-936f-42a7-9daa-dd71cef34936)