### PR TITLE
Display "recent workspace" when opening repo fails

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -60,21 +60,24 @@ impl GGSettings for UserSettings {
     }
 }
 
-pub fn read_config(repo_path: &Path) -> Result<(UserSettings, RevsetAliasesMap)> {
-    let mut default_layers = default_config_layers();
-    let gg_layer = ConfigLayer::parse(ConfigSource::Default, include_str!("./config/gg.toml"))?;
-    default_layers.push(gg_layer);
-    let mut raw_config = config_from_environment(default_layers);
-
+pub fn read_config(repo_path: Option<&Path>) -> Result<(UserSettings, RevsetAliasesMap)> {
+    let mut layers = vec![];
     let mut config_env = ConfigEnv::from_environment(&Ui::null());
 
-    config_env.reload_user_config(&mut raw_config)?;
+    let jj_default_layers = default_config_layers();
+    let gg_default_layer =
+        ConfigLayer::parse(ConfigSource::Default, include_str!("./config/gg.toml"))?;
+    layers.extend(jj_default_layers);
+    layers.push(gg_default_layer);
 
-    config_env.reset_repo_path(repo_path);
-    config_env.reload_repo_config(&mut raw_config)?;
+    let mut raw_config = config_from_environment(layers);
+    config_env.reload_user_config(&mut raw_config)?;
+    if let Some(repo_path) = repo_path {
+        config_env.reset_repo_path(repo_path);
+        config_env.reload_repo_config(&mut raw_config)?;
+    }
 
     let config = config_env.resolve_config(&raw_config)?;
-
     let aliases_map = build_aliases_map(&config)?;
     let settings = UserSettings::from_config(config)?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,7 +17,6 @@ use std::thread::{self, JoinHandle};
 
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
-#[cfg(windows)]
 use jj_lib::config::ConfigSource;
 use log::LevelFilter;
 use tauri::menu::Menu;
@@ -161,7 +160,9 @@ fn main() -> Result<()> {
             move_ref,
             git_push,
             git_fetch,
-            undo_operation
+            undo_operation,
+            query_recent_workspaces,
+            open_workspace_at_path,
         ])
         .menu(menu::build_main)
         .setup(|app| {
@@ -642,4 +643,39 @@ fn add_recent_workspaces(window: Window, repo_path: &str) -> Result<()> {
     })?;
 
     Ok(())
+}
+
+#[tauri::command(async)]
+fn query_recent_workspaces(
+    window: Window,
+    app_state: State<AppState>,
+) -> Result<Vec<String>, InvokeError> {
+    let session_tx: Sender<SessionEvent> = app_state.get_session(window.label());
+    let (call_tx, call_rx) = channel();
+    session_tx
+        .send(SessionEvent::ReadConfigArray {
+            key: vec![
+                "gg".to_string(),
+                "ui".to_string(),
+                "recent-workspaces".to_string(),
+            ],
+            tx: call_tx,
+        })
+        .map_err(InvokeError::from_error)?;
+
+    match call_rx.recv().map_err(InvokeError::from_error)? {
+        Ok(workspaces) => Ok(workspaces),
+        Err(_) => Ok(vec![]),
+    }
+}
+
+#[tauri::command]
+fn open_workspace_at_path(window: Window, path: String) -> Result<(), InvokeError> {
+    match try_open_repository(&window, Some(PathBuf::from(path))) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            log::error!("try_open_repository: {err:#}");
+            Err(InvokeError::from_anyhow(err))
+        }
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -539,15 +539,10 @@ fn try_open_repository(window: &Window, cwd: Option<PathBuf>) -> Result<()> {
                 messages::RepoConfig::Workspace { absolute_path, .. } => {
                     let repo_path = absolute_path.0.clone();
                     window.set_title((String::from("GG - ") + repo_path.as_str()).as_str())?;
-
-                    // on windows, update the shell jumplist; this can be slow
-                    #[cfg(windows)]
                     {
                         let window = window.clone();
                         thread::spawn(move || {
-                            handler::nonfatal!(with_recent_workspaces(window, |recent| {
-                                windows::update_jump_list(recent, &repo_path)
-                            }));
+                            handler::nonfatal!(add_recent_workspaces(window, &repo_path));
                         });
                     }
                 }
@@ -612,11 +607,7 @@ fn handle_window_event(window: &Window, event: &WindowEvent) {
     }
 }
 
-#[cfg(windows)]
-fn with_recent_workspaces(
-    window: Window,
-    f: impl FnOnce(&mut Vec<String>) -> Result<()>,
-) -> Result<()> {
+fn add_recent_workspaces(window: Window, repo_path: &str) -> Result<()> {
     let app_state = window.state::<AppState>();
     let session_tx: Sender<SessionEvent> = app_state.get_session(window.label());
 
@@ -630,8 +621,15 @@ fn with_recent_workspaces(
         tx: read_tx,
     })?;
     let mut recent = read_rx.recv()??;
+    recent.retain(|x| x != repo_path);
+    recent.insert(0, repo_path.to_owned());
+    recent.truncate(5);
 
-    f(&mut recent)?;
+    #[cfg(windows)]
+    {
+        // update the shell jumplist; this can be slow
+        windows::update_jump_list(&mut recent)?;
+    }
 
     session_tx.send(SessionEvent::WriteConfigArray {
         key: vec![

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -19,7 +19,7 @@ pub fn reattach_console() {
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
-pub fn update_jump_list(recent: &mut Vec<String>, path: &String) -> Result<()> {
+pub fn update_jump_list(recent: &mut Vec<String>) -> Result<()> {
     // create a jump list
     // safety: FFI
     let jump_list: ICustomDestinationList =
@@ -42,10 +42,6 @@ pub fn update_jump_list(recent: &mut Vec<String>, path: &String) -> Result<()> {
             }
         }
     };
-
-    // add the new path as most-recent and trim to the configured max size
-    recent.retain(|x| x != path);
-    recent.insert(0, path.to_owned());
 
     // safety: FFI
     let items: IObjectCollection =

--- a/src-tauri/src/worker/gui_util.rs
+++ b/src-tauri/src/worker/gui_util.rs
@@ -102,7 +102,7 @@ impl WorkerSession {
         let factory = DefaultWorkspaceLoaderFactory;
         let loader = factory.create(find_workspace_dir(cwd))?;
 
-        let (settings, aliases_map) = read_config(loader.repo_path())?;
+        let (settings, aliases_map) = read_config(Some(loader.repo_path()))?;
 
         let workspace = loader.load(
             &settings,

--- a/src-tauri/src/worker/session.rs
+++ b/src-tauri/src/worker/session.rs
@@ -293,7 +293,7 @@ impl Session for WorkspaceSession<'_> {
                     handler::optional!(path);
 
                     (self.data.settings, self.data.aliases_map) =
-                        read_config(self.workspace.repo_path())?;
+                        read_config(Some(self.workspace.repo_path()))?;
                 }
             };
         }

--- a/src/shell/RecentWorkspaces.svelte
+++ b/src/shell/RecentWorkspaces.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import { trigger } from "../ipc.js";
+
+    export let workspaces: string[] = [];
+</script>
+
+{#if workspaces.length > 0}
+    <div class="recent-workspaces">
+        <p><strong>recent workspaces:</strong></p>
+        <ul class="workspaces-list">
+            {#each workspaces as workspace}
+                <li class="workspace-item">
+                    <button
+                        class="workspace-button"
+                        on:click={() =>
+                            trigger("open_workspace_at_path", {
+                                path: workspace,
+                            })}
+                        title="open this workspace">
+                        {workspace}
+                    </button>
+                </li>
+            {/each}
+        </ul>
+    </div>
+{/if}
+
+<style>
+    .recent-workspaces {
+        margin-top: 16px;
+    }
+
+    .workspaces-list {
+        text-align: left;
+        margin: 8px 0;
+        padding-left: 20px;
+    }
+
+    .workspace-item {
+        margin: 10px 0;
+        font-family: monospace;
+        font-size: 12px;
+        color: var(--ctp-subtext1);
+    }
+
+    .workspace-button {
+        background: none;
+        border: none;
+        color: var(--ctp-blue);
+        cursor: pointer;
+        text-decoration: none;
+        font-family: monospace;
+        font-size: 18px;
+        padding: 0;
+        text-align: left;
+    }
+
+    .workspace-button:hover {
+        color: var(--ctp-sky);
+        text-decoration: underline;
+    }
+</style>


### PR DESCRIPTION
Implemented displaying recently successfully opened repository paths when failing to open a repository, significantly improving usability when directly running gg.exe or opening gg from any path.

> Demo:

![2025-06-17 22-30-13](https://github.com/user-attachments/assets/dfca67ee-7bd4-4286-a098-0a626af4eb4f)
