### PR TITLE
add more right-click options for changed files

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -224,6 +224,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.7",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.0.7",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +306,30 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.7",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -276,6 +373,12 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -398,6 +501,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
 dependencies = [
  "objc2 0.6.1",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -2845,6 +2961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,6 +4125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4314,6 +4445,19 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "opener"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771b9704f8cd8b424ec747a320b30b47517a6966ba2c7da90047c16f4a962223"
+dependencies = [
+ "bstr",
+ "normpath",
+ "url",
+ "windows-sys 0.59.0",
+ "zbus",
 ]
 
 [[package]]
@@ -4671,6 +4815,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +4855,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.0.7",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7193,6 +7362,7 @@ dependencies = [
  "jj-cli",
  "jj-lib",
  "log",
+ "opener",
  "pollster 0.3.0",
  "serde",
  "serde_json",
@@ -8206,8 +8376,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,6 +61,7 @@ chrono = { version = "0.4.38", features = ["serde"] }
 git2 = { version = "0.20.1", features = ["vendored-libgit2"] }
 
 # extra deps not used by JJ
+opener = { version = "0.8.2", features = ["reveal"] }
 log = "0.4"
 futures-util = "0.3.30"
 ts-rs = { version = "7.1.1", features = ["chrono-impl"], optional = true }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -163,6 +163,8 @@ fn main() -> Result<()> {
             undo_operation,
             query_recent_workspaces,
             open_workspace_at_path,
+            open_file_in_explorer,
+            open_file_with_default_app,
         ])
         .menu(menu::build_main)
         .setup(|app| {
@@ -678,4 +680,16 @@ fn open_workspace_at_path(window: Window, path: String) -> Result<(), InvokeErro
             Err(InvokeError::from_anyhow(err))
         }
     }
+}
+
+#[tauri::command(async, rename_all = "snake_case")]
+fn open_file_in_explorer(file_path: String) -> Result<(), InvokeError> {
+    opener::reveal(&file_path).map_err(|e| InvokeError::from_anyhow(e.into()))?;
+    Ok(())
+}
+
+#[tauri::command(async, rename_all = "snake_case")]
+fn open_file_with_default_app(file_path: String) -> Result<(), InvokeError> {
+    opener::open(&file_path).map_err(|e| InvokeError::from_anyhow(e.into()))?;
+    Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -549,9 +549,7 @@ fn try_open_repository(window: &Window, cwd: Option<PathBuf>) -> Result<()> {
                         });
                     }
                 }
-                _ => {
-                    window.set_title("vizjj - Gui for JJ")?;
-                }
+                _ => window.set_title("vizjj - Gui for JJ")?,
             }
             window.emit("vizjj://repo/config", config)?;
         }
@@ -629,10 +627,8 @@ fn add_recent_workspaces(window: Window, repo_path: &str) -> Result<()> {
     recent.truncate(5);
 
     #[cfg(windows)]
-    {
-        // update the shell jumplist; this can be slow
-        windows::update_jump_list(&mut recent)?;
-    }
+    // update the shell jumplist; this can be slow
+    windows::update_jump_list(&mut recent)?;
 
     session_tx.send(SessionEvent::WriteConfigArray {
         key: vec![

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -409,11 +409,9 @@ pub fn handle_context(window: Window, ctx: Operand) -> Result<()> {
                 "branch_untrack",
                 matches!(
                     r#ref,
-                    StoreRef::LocalBookmark {
-                        ref tracking_remotes,
-                        ..
-                    } if !tracking_remotes.is_empty()
-                ) || matches!(
+                    StoreRef::LocalBookmark { ref tracking_remotes, ..} if !tracking_remotes.is_empty()
+                )
+                || matches!(
                     r#ref,
                     StoreRef::RemoteBookmark {
                         is_synced: false, // we can *see* the remote ref, and
@@ -426,8 +424,8 @@ pub fn handle_context(window: Window, ctx: Operand) -> Result<()> {
 
             // push a local to its remotes, or finish a CLI delete
             context_menu.enable("branch_push_all",
-                matches!(r#ref, StoreRef::LocalBookmark { ref tracking_remotes, .. } if !tracking_remotes.is_empty()) ||
-                matches!(r#ref, StoreRef::RemoteBookmark { is_tracked: true, is_absent: true, .. }))?;
+                matches!(r#ref, StoreRef::LocalBookmark { ref tracking_remotes, .. } if !tracking_remotes.is_empty())
+                || matches!(r#ref, StoreRef::RemoteBookmark { is_tracked: true, is_absent: true, .. }))?;
 
             // push a local to a selected remote, tracking first if necessary
             context_menu.enable("branch_push_single",
@@ -435,8 +433,8 @@ pub fn handle_context(window: Window, ctx: Operand) -> Result<()> {
 
             // fetch a local's remotes, or just a remote (unless we're deleting it; that would be silly)
             context_menu.enable("branch_fetch_all",
-                matches!(r#ref, StoreRef::LocalBookmark { ref tracking_remotes, .. } if !tracking_remotes.is_empty()) ||
-                matches!(r#ref, StoreRef::RemoteBookmark { is_tracked, is_absent, .. } if (!is_tracked || !is_absent)))?;
+                matches!(r#ref, StoreRef::LocalBookmark { ref tracking_remotes, .. } if !tracking_remotes.is_empty())
+                || matches!(r#ref, StoreRef::RemoteBookmark { is_tracked, is_absent, .. } if (!is_tracked || !is_absent)))?;
 
             // fetch a local, tracking first if necessary
             context_menu.enable("branch_fetch_single",
@@ -534,20 +532,18 @@ trait Enabler {
 
 impl Enabler for Menu<Wry> {
     fn enable(&self, id: &str, value: bool) -> tauri::Result<()> {
-        if let Some(item) = self.get(id).as_ref().and_then(|item| item.as_menuitem()) {
-            item.set_enabled(value)
-        } else {
-            Ok(())
+        match self.get(id).as_ref().and_then(|item| item.as_menuitem()) {
+            Some(item) => item.set_enabled(value),
+            None => Ok(()),
         }
     }
 }
 
 impl Enabler for Submenu<Wry> {
     fn enable(&self, id: &str, value: bool) -> tauri::Result<()> {
-        if let Some(item) = self.get(id).as_ref().and_then(|item| item.as_menuitem()) {
-            item.set_enabled(value)
-        } else {
-            Ok(())
+        match self.get(id).as_ref().and_then(|item| item.as_menuitem()) {
+            Some(item) => item.set_enabled(value),
+            None => Ok(()),
         }
     }
 }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -232,6 +232,35 @@ pub fn build_context(
                 true,
                 None::<&str>,
             )?,
+            &PredefinedMenuItem::separator(app_handle)?,
+            &MenuItem::with_id(
+                app_handle,
+                "file_open_with_default_app",
+                "Open with Default App",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(
+                app_handle,
+                "file_open_in_explorer",
+                "Open in File Explorer",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(
+                app_handle,
+                "file_copy_full_path",
+                "Copy File Path",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(
+                app_handle,
+                "file_copy_relative_path",
+                "Copy Relative Path",
+                true,
+                None::<&str>,
+            )?,
         ],
     )?;
 
@@ -472,6 +501,12 @@ pub fn handle_event(window: &Window, event: MenuEvent) -> Result<()> {
         "branch_fetch_single" => window.emit("vizjj://context/branch", "fetch-single")?,
         "branch_rename" => window.emit("vizjj://context/branch", "rename")?,
         "branch_delete" => window.emit("vizjj://context/branch", "delete")?,
+        "file_open_with_default_app" => {
+            window.emit("vizjj://context/file", "open-with-default-app")?
+        }
+        "file_open_in_explorer" => window.emit("vizjj://context/file", "open-in-explorer")?,
+        "file_copy_full_path" => window.emit("vizjj://context/file", "copy-full-path")?,
+        "file_copy_relative_path" => window.emit("vizjj://context/file", "copy-relative-path")?,
         _ => (),
     };
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,6 +11,7 @@
     import type { RevId } from "./messages/RevId";
     import type { RevResult } from "./messages/RevResult";
     import ChangeMutator from "./mutators/ChangeMutator";
+    import FileMutator from "./mutators/FileMutator";
     import RefMutator from "./mutators/RefMutator";
     import RevisionMutator from "./mutators/RevisionMutator";
     import Zone from "./objects/Zone.svelte";
@@ -73,6 +74,7 @@
     onEvent("vizjj://context/revision", mutateRevision);
     onEvent("vizjj://context/tree", mutateTree);
     onEvent("vizjj://context/branch", mutateRef);
+    onEvent("vizjj://context/file", mutateFile);
     onEvent("vizjj://input", requestInput);
 
     $effect(() => {
@@ -140,6 +142,15 @@
     function mutateRef(event: string) {
         if ($currentContext?.type == "Ref") {
             new RefMutator($currentContext.ref).handle(event);
+        }
+        $currentContext = null;
+    }
+
+    function mutateFile(event: string) {
+        if ($currentContext?.type == "Change") {
+            const workspaceRoot =
+                $repoConfigEvent?.type === "Workspace" ? $repoConfigEvent.absolute_path : "";
+            new FileMutator($currentContext.path, workspaceRoot).handle(event);
         }
         $currentContext = null;
     }

--- a/src/mutators/FileMutator.ts
+++ b/src/mutators/FileMutator.ts
@@ -1,0 +1,69 @@
+import type { TreePath } from "../messages/TreePath";
+import { trigger } from "../ipc";
+
+export default class FileMutator {
+    #path: TreePath;
+    #workspaceRoot: string;
+
+    constructor(path: TreePath, workspaceRoot: string = "") {
+        this.#path = path;
+        this.#workspaceRoot = workspaceRoot;
+    }
+
+    normalizePath(path: string): string {
+        return path.replace(/\\/g, "/");
+    }
+
+    buildFullPath(): string {
+        if (!this.#workspaceRoot) {
+            return this.normalizePath(this.#path.repo_path);
+        }
+        const cleanRoot = this.normalizePath(this.#workspaceRoot).replace(/\/$/, "");
+        const cleanRepoPath = this.normalizePath(this.#path.repo_path).replace(/^\//, "");
+        return `${cleanRoot}/${cleanRepoPath}`;
+    }
+
+    handle(event: string | undefined) {
+        if (!event) {
+            return;
+        }
+
+        switch (event) {
+            case "open-with-default-app":
+                this.onOpenWithDefaultApp();
+                break;
+            case "open-in-explorer":
+                this.onOpenInExplorer();
+                break;
+            case "copy-full-path":
+                this.onCopyFullPath();
+                break;
+            case "copy-relative-path":
+                this.onCopyRelativePath();
+                break;
+            default:
+                console.log(`unimplemented file operation '${event}'`, this);
+        }
+    }
+
+    onOpenWithDefaultApp() {
+        trigger("open_file_with_default_app", { file_path: this.buildFullPath() });
+    }
+
+    onOpenInExplorer() {
+        trigger("open_file_in_explorer", { file_path: this.buildFullPath() });
+    }
+
+    onCopyFullPath() {
+        navigator.clipboard.writeText(this.buildFullPath()).catch((err) => {
+            console.error("Failed to copy full path to clipboard:", err);
+        });
+    }
+
+    onCopyRelativePath() {
+        const relativePath = this.normalizePath(this.#path.relative_path || this.#path.repo_path);
+        navigator.clipboard.writeText(relativePath).catch((err) => {
+            console.error("Failed to copy relative path to clipboard:", err);
+        });
+    }
+}


### PR DESCRIPTION
complet: #47  

Now, by right-clicking on the changed file, you can:  
1. Open with the default application  
2. Open in File Explorer  
3. Copy the file path (absolute)  
4. Copy the relative path  

The path separator uses `/`.

现在, 通过右击变更的文件, 你可以:
1. 以默认应用打开
2. 在资源管理器中打开
3. 复制文件路径(绝对)
4. 复制相对路径

其中路径分隔符使用`/`


demo:


https://github.com/user-attachments/assets/cdf08f07-53b6-4675-9a3b-d0751c9bfbd5

